### PR TITLE
chore: pass device parameter to model and processor initialization

### DIFF
--- a/src/liquid_audio/demo/model.py
+++ b/src/liquid_audio/demo/model.py
@@ -23,5 +23,5 @@ mimi = proc.mimi.eval()
 logging.info("Warmup tokenizer")
 with mimi.streaming(1), torch.no_grad():
     for _ in range(5):
-        x = torch.randint(2048, (1, 8, 1), device="cuda")
+        x = torch.randint(2048, (1, 8, 1), device=DEVICE)
         mimi.decode(x)

--- a/src/liquid_audio/demo/model.py
+++ b/src/liquid_audio/demo/model.py
@@ -11,11 +11,12 @@ logger = logging.getLogger(__name__)
 __all__ = ["lfm2_audio", "mimi", "proc"]
 
 HF_DIR = "LiquidAI/LFM2-Audio-1.5B"
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
 logging.info("Loading processor")
-proc = LFM2AudioProcessor.from_pretrained(HF_DIR).eval()
+proc = LFM2AudioProcessor.from_pretrained(HF_DIR, device=DEVICE).eval()
 logging.info("Loading model")
-lfm2_audio = LFM2AudioModel.from_pretrained(HF_DIR).eval()
+lfm2_audio = LFM2AudioModel.from_pretrained(HF_DIR, device=DEVICE).eval()
 logging.info("Loading tokenizer")
 mimi = proc.mimi.eval()
 


### PR DESCRIPTION
This pull request updates the model and processor loading logic in `src/liquid_audio/demo/model.py` to ensure that they are loaded on the appropriate device (GPU if available, otherwise CPU). This improves performance on systems with CUDA-enabled GPUs.

Device management improvements:

* Added automatic device selection by defining a `DEVICE` variable that uses "cuda" if available, otherwise "cpu". Updated both `LFM2AudioProcessor.from_pretrained` and `LFM2AudioModel.from_pretrained` to load models onto the selected device.