### PR TITLE
Refactor: Migrate from logging to loguru for better logging experience

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "accelerate>=1.10.1",
     "einops>=0.8.1",
     "librosa>=0.11.0",
+    "loguru>=0.7.3",
     "sentencepiece>=0.2.1",
     "torch>=2.8.0",
     "torchaudio>=2.8.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,21 @@
+# Liquid Audio - Core Dependencies
+# Python >= 3.12 required
+
+# Deep Learning Framework
+torch>=2.8.0
+torchaudio>=2.8.0
+
+# Model & Training
+accelerate>=1.10.1
+transformers>=4.55.4
+
+# Audio Processing
+librosa>=0.11.0
+
+# Utilities
+einops>=0.8.1
+sentencepiece>=0.2.1
+loguru>=0.7.3
+
+# Optional: Flash Attention (uncomment if needed)
+# flash-attn>=2.0.0  # Install with: pip install flash-attn --no-build-isolation

--- a/src/liquid_audio/demo/model.py
+++ b/src/liquid_audio/demo/model.py
@@ -1,25 +1,24 @@
 """Initialize models"""
 
-import logging
+from loguru import logger
 
 import torch
 
 from liquid_audio import LFM2AudioModel, LFM2AudioProcessor
 
-logger = logging.getLogger(__name__)
 
 __all__ = ["lfm2_audio", "mimi", "proc"]
 
 HF_DIR = "LiquidAI/LFM2-Audio-1.5B"
 
-logging.info("Loading processor")
+logger.info("Loading processor")
 proc = LFM2AudioProcessor.from_pretrained(HF_DIR).eval()
-logging.info("Loading model")
+logger.info("Loading model")
 lfm2_audio = LFM2AudioModel.from_pretrained(HF_DIR).eval()
-logging.info("Loading tokenizer")
+logger.info("Loading tokenizer")
 mimi = proc.mimi.eval()
 
-logging.info("Warmup tokenizer")
+logger.info("Warmup tokenizer")
 with mimi.streaming(1), torch.no_grad():
     for _ in range(5):
         x = torch.randint(2048, (1, 8, 1), device="cuda")

--- a/src/liquid_audio/model/conformer/encoder.py
+++ b/src/liquid_audio/model/conformer/encoder.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from torch import nn
 import torch
 
+from loguru import logger
 from .mha import MultiHeadAttention, RelPositionalEncoding
 from .modules import CausalConv1D, ConformerLayer
 from .subsampling import ConvSubsampling
@@ -912,7 +913,7 @@ class ConformerEncoder(nn.Module):
             att_context_size (list): The attention context size to be set.
         """
         if att_context_size not in self.att_context_size_all:
-            logging.warning(
+            logger.warning(
                 f"att_context_size={att_context_size} is not among the list of the supported "
                 f"look-aheads: {self.att_context_size_all}"
             )
@@ -970,7 +971,7 @@ class ConformerEncoder(nn.Module):
                 streaming_cfg.last_channel_cache_size = (
                     att_context_size[0] if att_context_size[0] >= 0 else max_context
                 )
-                logging.warning(
+                logger.warning(
                     f"left_chunks is not set. Setting it to default: {streaming_cfg.last_channel_cache_size}."
                 )
             else:
@@ -1209,7 +1210,7 @@ class ConformerEncoder(nn.Module):
         """
 
         if not hasattr(self.pre_encode, "change_subsampling_conv_chunking_factor"):
-            logging.info("Model pre_encoder doesn't have a change_subsampling_conv_chunking_factor method ")
+            logger.info("Model pre_encoder doesn't have a change_subsampling_conv_chunking_factor method ")
             return
 
         self.pre_encode.change_subsampling_conv_chunking_factor(

--- a/src/liquid_audio/model/conformer/processor.py
+++ b/src/liquid_audio/model/conformer/processor.py
@@ -16,7 +16,7 @@
 Adapted from https://github.com/NVIDIA/NeMo/blob/09a962536c7a52f1964224e6e687ffb4a34fef79/nemo/collections/asr/modules/audio_preprocessing.py#L61
 """
 
-import logging
+from loguru import logger
 from abc import ABC, abstractmethod
 import random
 
@@ -60,7 +60,7 @@ class AudioPreprocessor(nn.Module, ABC):
     @torch.no_grad()
     def forward(self, input_signal, length):
         if input_signal.dtype != torch.float32:
-            logging.warning(
+            logger.warning(
                 f"AudioPreprocessor received an input signal of dtype {input_signal.dtype}, rather than torch.float32. In sweeps across multiple datasets, we have found that the preprocessor is not robust to low precision  mathematics. As such, it runs in float32. Your input will be cast to float32, but this is not necessarily enough to recovery full accuracy. For example, simply casting input_signal from torch.float32 to torch.bfloat16, then back to torch.float32 before running AudioPreprocessor causes drops in absolute WER of up to 0.1%. torch.bfloat16 simply does not have enough mantissa bits to represent enough values in the range [-1.0,+1.0] correctly.",
             )
         processed_signal, processed_length = self.get_features(input_signal.to(torch.float32), length)
@@ -305,7 +305,7 @@ class FilterbankFeatures(nn.Module):
     ):
         super().__init__()
         if stft_conv or stft_exact_pad:
-            logging.warning(
+            logger.warning(
                 "Using torch_stft is deprecated and has been removed. The values have been forcibly set to False "
                 "for FilterbankFeatures and AudioToMelSpectrogramPreprocessor. Please set exact_pad to True "
                 "as needed."
@@ -328,7 +328,7 @@ class FilterbankFeatures(nn.Module):
                 f"{self} got an invalid value for either n_window_size or "
                 f"n_window_stride. Both must be positive ints."
             )
-        logging.info(f"PADDING: {pad_to}")
+        logger.info(f"PADDING: {pad_to}")
 
         self.sample_rate = sample_rate
         self.win_length = n_window_size
@@ -339,7 +339,7 @@ class FilterbankFeatures(nn.Module):
         self.sample_rate = sample_rate
 
         if exact_pad:
-            logging.info("STFT using exact pad")
+            logger.info("STFT using exact pad")
         torch_windows = {
             'hann': torch.hann_window,
             'hamming': torch.hamming_window,
@@ -398,15 +398,15 @@ class FilterbankFeatures(nn.Module):
         # log_zero_guard_value is the the small we want to use, we support
         # an actual number, or "tiny", or "eps"
         self.log_zero_guard_type = log_zero_guard_type
-        logging.debug(f"sr: {sample_rate}")
-        logging.debug(f"n_fft: {self.n_fft}")
-        logging.debug(f"win_length: {self.win_length}")
-        logging.debug(f"hop_length: {self.hop_length}")
-        logging.debug(f"n_mels: {nfilt}")
-        logging.debug(f"fmin: {lowfreq}")
-        logging.debug(f"fmax: {highfreq}")
-        logging.debug(f"using grads: {use_grads}")
-        logging.debug(f"nb_augmentation_prob: {nb_augmentation_prob}")
+        logger.debug(f"sr: {sample_rate}")
+        logger.debug(f"n_fft: {self.n_fft}")
+        logger.debug(f"win_length: {self.win_length}")
+        logger.debug(f"hop_length: {self.hop_length}")
+        logger.debug(f"n_mels: {nfilt}")
+        logger.debug(f"fmin: {lowfreq}")
+        logger.debug(f"fmax: {highfreq}")
+        logger.debug(f"using grads: {use_grads}")
+        logger.debug(f"nb_augmentation_prob: {nb_augmentation_prob}")
 
     def stft(self, x):
         return torch.stft(

--- a/src/liquid_audio/model/conformer/subsampling.py
+++ b/src/liquid_audio/model/conformer/subsampling.py
@@ -17,13 +17,11 @@
 adapted from https://github.com/NVIDIA/NeMo/blob/c83adff36efaa549f7bdd26e97c01a60e9f9026b/nemo/collections/asr/parts/submodules/subsampling.py
 """
 
-import logging
+from loguru import logger
 import math
 
 import torch
 from torch import nn
-
-logger = logging.getLogger(__name__)
 
 class ConvSubsampling(torch.nn.Module):
     """Convolutional subsampling which supports VGGNet and striding approach introduced in:

--- a/src/liquid_audio/moshi/conditioners/base.py
+++ b/src/liquid_audio/moshi/conditioners/base.py
@@ -6,7 +6,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 
-import logging
+from loguru import logger
 import typing as tp
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -17,7 +17,6 @@ from torch import nn
 
 from ..modules.transformer import create_sin_embedding
 
-logger = logging.getLogger(__name__)
 TextCondition = tp.Optional[str]  # a text condition can be a string or None (if doesn't exist)
 ConditionTensors = dict[str, 'ConditionType']
 

--- a/src/liquid_audio/moshi/conditioners/text.py
+++ b/src/liquid_audio/moshi/conditioners/text.py
@@ -2,7 +2,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 import hashlib
-import logging
+from loguru import logger
 import typing as tp
 
 import torch
@@ -10,9 +10,6 @@ from torch import nn
 
 
 from .base import _BaseTextConditioner, ConditionType
-
-
-logger = logging.getLogger(__name__)
 
 
 def length_to_mask(lengths: torch.Tensor, max_len: tp.Optional[int] = None) -> torch.Tensor:

--- a/src/liquid_audio/moshi/models/compression.py
+++ b/src/liquid_audio/moshi/models/compression.py
@@ -15,7 +15,7 @@ for Mimi. Also defines the main interface that a model must follow to be usable 
 
 from abc import abstractmethod
 from dataclasses import dataclass
-import logging
+from loguru import logger
 import typing as tp
 
 import torch
@@ -34,7 +34,6 @@ from ..modules.streaming import StreamingModule, State, StateT
 from ..utils.compile import CUDAGraphed
 
 
-logger = logging.getLogger()
 
 
 class CompressionModel(StreamingModule[StateT]):

--- a/src/liquid_audio/moshi/models/lm.py
+++ b/src/liquid_audio/moshi/models/lm.py
@@ -8,7 +8,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-import logging
+from loguru import logger
 import typing as tp
 from contextlib import ExitStack
 from dataclasses import dataclass, field
@@ -25,7 +25,6 @@ from ..utils.quantize import replace_linear_with_qlinear
 from ..utils.sampling import sample_token
 from .lm_utils import ScaledEmbedding, _delay_sequence, _init_layer, _undelay_sequence
 
-logger = logging.getLogger(__name__)
 
 
 def scatter_with_mask_(tensor: torch.Tensor, dim: int,

--- a/src/liquid_audio/utils.py
+++ b/src/liquid_audio/utils.py
@@ -3,6 +3,7 @@ from functools import cache
 from pathlib import Path
 
 import torch
+from loguru import logger
 from huggingface_hub import snapshot_download
 
 
@@ -48,6 +49,7 @@ def get_model_dir(
         cache_path = Path(snapshot_download(repo_id, revision=revision))
     else:
         if revision is not None:
+            logger.error("cannot use `revision` kwarg when given a path")
             raise RuntimeError("cannot use `revision` kwarg when given a path")
         cache_path = repo_id
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -812,6 +812,7 @@ dependencies = [
     { name = "accelerate" },
     { name = "einops" },
     { name = "librosa" },
+    { name = "loguru" },
     { name = "sentencepiece" },
     { name = "torch" },
     { name = "torchaudio" },
@@ -836,6 +837,7 @@ requires-dist = [
     { name = "einops", specifier = ">=0.8.1" },
     { name = "fastrtc", extras = ["vad"], marker = "extra == 'demo'", specifier = ">=0.0.30" },
     { name = "librosa", specifier = ">=0.11.0" },
+    { name = "loguru", specifier = ">=0.7.3" },
     { name = "sentencepiece", specifier = ">=0.2.1" },
     { name = "torch", specifier = ">=2.8.0" },
     { name = "torchaudio", specifier = ">=2.8.0" },
@@ -866,6 +868,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/1b/656f5a357de7135a3777bd735cc7c9b8f23b4d37465505bd0eaf4be9befe/llvmlite-0.44.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46224058b13c96af1365290bdfebe9a6264ae62fb79b2b55693deed11657a8bf", size = 42361904, upload-time = "2025-01-20T11:14:22.949Z" },
     { url = "https://files.pythonhosted.org/packages/d8/e1/12c5f20cb9168fb3464a34310411d5ad86e4163c8ff2d14a2b57e5cc6bac/llvmlite-0.44.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0097052c32bf721a4efc03bd109d335dfa57d9bffb3d4c24cc680711b8b4fc", size = 41184245, upload-time = "2025-01-20T11:14:31.731Z" },
     { url = "https://files.pythonhosted.org/packages/d0/81/e66fc86539293282fd9cb7c9417438e897f369e79ffb62e1ae5e5154d4dd/llvmlite-0.44.0-cp313-cp313-win_amd64.whl", hash = "sha256:2fb7c4f2fb86cbae6dca3db9ab203eeea0e22d73b99bc2341cdf9de93612e930", size = 30331193, upload-time = "2025-01-20T11:14:38.578Z" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
 ]
 
 [[package]]
@@ -2409,4 +2424,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
     { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]


### PR DESCRIPTION

## Summary
- Add loguru>=0.7.3 to project dependencies in pyproject.toml
- Update uv.lock to include loguru and its dependencies
- Create requirements.txt for easier pip-based installation