### PR TITLE
Fix TTS Support For Apple MPS

### DIFF
--- a/src/liquid_audio/processor.py
+++ b/src/liquid_audio/processor.py
@@ -89,9 +89,7 @@ class LFM2AudioProcessor:
         mimi_model = moshi.models.loaders.get_mimi(None, device=self.device)
         
         # safetensors doesn't support MPS device, so load to CPU first and let the model move it
-        load_device = str(self.device)
-        if torch.mps.is_available():
-            load_device = "cpu"
+        load_device = "cpu" if self.device.type == "mps" else str(self.device)
         
         mimi_weights = load_file(self.mimi_weights_path, device=load_device)
         mimi_model.load_state_dict(mimi_weights, strict=True)

--- a/src/liquid_audio/processor.py
+++ b/src/liquid_audio/processor.py
@@ -87,7 +87,13 @@ class LFM2AudioProcessor:
         from safetensors.torch import load_file
 
         mimi_model = moshi.models.loaders.get_mimi(None, device=self.device)
-        mimi_weights = load_file(self.mimi_weights_path, device=str(self.device))
+        
+        # safetensors doesn't support MPS device, so load to CPU first and let the model move it
+        load_device = str(self.device)
+        if torch.mps.is_available():
+            load_device = "cpu"
+        
+        mimi_weights = load_file(self.mimi_weights_path, device=load_device)
         mimi_model.load_state_dict(mimi_weights, strict=True)
 
         return mimi_model


### PR DESCRIPTION
## Summary

This pull request adds MPS (Apple Silicon) device support for TTS with a **non-breaking change** to the Mimi model weight loading in `src/liquid_audio/processor.py`.

## Problem

The `safetensors` library doesn't support loading weights directly to MPS devices, causing an error: `device mps:0 is invalid` when attempting to use the library on Apple Silicon Macs.

## Solution

Added device detection logic in the `mimi` property to:
- Load weights to CPU first when the target device is MPS
- Let PyTorch automatically transfer weights to MPS during `load_state_dict()`
- Preserve existing behavior for CUDA, CPU devices, and MPS devices using CPU (no changes)

## Changes

- Modified `src/liquid_audio/processor.py`: Added MPS device detection to conditionally load weights via CPU as an intermediate step

## Impact

- ✅ **Non-breaking**: No changes to existing CUDA/CPU workflows
- ✅ **Enables MPS support**: Users can now run on Apple Silicon devices
- ✅ **Minimal change**: Single-line conditional added for device compatibility