### PR TITLE
Use CPU if CUDA isn't available. Use mps if available.

### DIFF
--- a/src/liquid_audio/demo/chat.py
+++ b/src/liquid_audio/demo/chat.py
@@ -91,7 +91,7 @@ def chat_response(audio: tuple[int, np.ndarray], _id: str, chat: ChatState, temp
     chat.append(
         text=torch.stack(out_text, 1),
         audio_out=torch.stack(out_audio, 1),
-        modality_flag=torch.tensor(out_modality, device="cuda"),
+        modality_flag=torch.tensor(out_modality, device=chat.device),
     )
 
     chat.end_turn()

--- a/src/liquid_audio/demo/model.py
+++ b/src/liquid_audio/demo/model.py
@@ -22,5 +22,5 @@ mimi = proc.mimi.eval()
 logging.info("Warmup tokenizer")
 with mimi.streaming(1), torch.no_grad():
     for _ in range(5):
-        x = torch.randint(2048, (1, 8, 1), device="cuda")
+        x = torch.randint(2048, (1, 8, 1), device=proc.device)
         mimi.decode(x)

--- a/src/liquid_audio/model/lfm2_audio.py
+++ b/src/liquid_audio/model/lfm2_audio.py
@@ -18,7 +18,7 @@ from liquid_audio.model.conformer.encoder import ConformerEncoder, ConformerEnco
 from liquid_audio.model.mlp import MLP
 from liquid_audio.model.transformer import MHA, RawLMBackbone, SharedEmbedding, StandardBlock
 from liquid_audio.processor import PreprocessorConfig
-from liquid_audio.utils import LFMModality, get_model_dir, mel2emb_len, module_exists
+from liquid_audio.utils import LFMModality, get_default_device, get_model_dir, mel2emb_len, module_exists
 
 
 class LFM2_HFConfig(TypedDict):
@@ -124,8 +124,10 @@ class LFM2AudioModel(nn.Module):
         *,
         revision: str | None = None,
         dtype: torch.dtype = torch.bfloat16,
-        device: torch.device | str = "cuda",
+        device: torch.device | str | None = None,
     ) -> Self:
+        if device is None:
+            device = get_default_device()
         cache_path = get_model_dir(repo_id, revision=revision)
 
         with (cache_path / "config.json").open() as f:

--- a/src/liquid_audio/processor.py
+++ b/src/liquid_audio/processor.py
@@ -89,7 +89,9 @@ class LFM2AudioProcessor:
         from safetensors.torch import load_file
 
         mimi_model = moshi.models.loaders.get_mimi(None, device=self.device)
-        mimi_weights = load_file(self.mimi_weights_path, device=str(self.device))
+        # safetensors doesn't support MPS directly, load to CPU first
+        load_device = "cpu" if self.device.type == "mps" else str(self.device)
+        mimi_weights = load_file(self.mimi_weights_path, device=load_device)
         mimi_model.load_state_dict(mimi_weights, strict=True)
 
         return mimi_model

--- a/src/liquid_audio/processor.py
+++ b/src/liquid_audio/processor.py
@@ -12,7 +12,7 @@ from transformers import AutoTokenizer, PreTrainedTokenizer
 from liquid_audio import moshi
 from liquid_audio.model.conformer.processor import AudioToMelSpectrogramPreprocessor
 from liquid_audio.moshi.models.compression import MimiModel
-from liquid_audio.utils import LFMModality, get_model_dir, mel2emb_len
+from liquid_audio.utils import LFMModality, get_default_device, get_model_dir, mel2emb_len
 
 
 @dataclass(kw_only=True)
@@ -50,8 +50,10 @@ class LFM2AudioProcessor:
         repo_id: str | Path,
         *,
         revision: str | None = None,
-        device: torch.device | str = "cuda",
+        device: torch.device | str | None = None,
     ) -> Self:
+        if device is None:
+            device = get_default_device()
         cache_path = get_model_dir(repo_id, revision=revision)
         with (cache_path / "config.json").open() as f:
             config = json.load(f)

--- a/src/liquid_audio/utils.py
+++ b/src/liquid_audio/utils.py
@@ -41,9 +41,14 @@ def get_default_device() -> str:
     """Get default device based on availability.
 
     Returns:
-        "cuda" if CUDA is available, otherwise "cpu"
+        "cuda" if CUDA is available, "mps" if MPS is available, otherwise "cpu"
     """
-    return "cuda" if torch.cuda.is_available() else "cpu"
+    if torch.cuda.is_available():
+        return "cuda"
+    elif torch.backends.mps.is_available():
+        return "mps"
+    else:
+        return "cpu"
 
 
 @cache

--- a/src/liquid_audio/utils.py
+++ b/src/liquid_audio/utils.py
@@ -37,6 +37,15 @@ def module_exists(name: str) -> bool:
     return spec is not None
 
 
+def get_default_device() -> str:
+    """Get default device based on availability.
+
+    Returns:
+        "cuda" if CUDA is available, otherwise "cpu"
+    """
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
 @cache
 def get_model_dir(
     repo_id: str | Path,


### PR DESCRIPTION
This change falls back to CPU if CUDA isn't available by default instead of just failing which is more useful for folks trying out the demo.
It will also use mps on Apple Silicon if available.