### PR TITLE
docs: add AMD/ROCm installation instructions (closes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,81 @@ pip install liquid-audio
 pip install "liquid-audio [demo]" # optional, to install demo dependencies
 pip install flash-attn --no-build-isolation  # optional, to use flash attention 2. Will fallback to torch SDPA if not installed
 ```
+### NVIDIA (default)
+
+The package can be installed via `pip`
+```bash
+pip install liquid-audio
+pip install "liquid-audio [demo]" # optional, to install demo dependencies
+pip install flash-attn --no-build-isolation  # optional, to use flash attention 2. Will fallback to torch SDPA if not installed
+```
+
+### AMD / ROCm (community)
+
+> **Note:** ROCm support is community-contributed and has been tested on ROCm 7.1. Flash Attention 2 is not supported on AMD GPUs; the model will automatically fall back to PyTorch SDPA.
+
+Running on AMD GPUs requires building from source with `uv` so that PyTorch and related packages are sourced from the ROCm wheel index instead of PyPI.
+
+**1. Clone the repository and enter the project folder**
+
+```bash
+git clone https://github.com/Liquid4All/liquid-audio.git
+cd liquid-audio
+```
+
+**2. Remove any existing virtual environment**
+
+```bash
+rm -rf .venv
+```
+
+**3. Add the ROCm index to `pyproject.toml`**
+
+Append the following to your `pyproject.toml`:
+
+```toml
+[tool.uv.sources]
+apex        = { index = "rocm" }
+torch       = { index = "rocm" }
+triton      = { index = "rocm" }
+torchaudio  = { index = "rocm" }
+torchvision = { index = "rocm" }
+
+[[tool.uv.index]]
+name    = "pypi"
+url     = "https://pypi.org/simple"
+default = true
+
+[[tool.uv.index]]
+name = "rocm"
+url  = "https://download.pytorch.org/whl/nightly/rocm7.1"
+```
+
+**4. Create a fresh virtual environment**
+
+```bash
+uv venv
+```
+
+**5. Install all dependencies**
+
+```bash
+uv sync
+```
+
+To also install the demo dependencies (Gradio interface):
+
+```bash
+uv sync --extra demo
+```
+
+**6. Run the demo**
+
+```bash
+uv run liquid-audio-demo
+```
+
+The demo interface will be available at http://localhost:7860.
 
 ## Usage
 Generation is handled by two generation modes, interleaved and sequential, accessible from the methods `LFM2AudioModel.generate_interleaved` and `LFM2AudioModel.generate_sequential` respectively. Both are generators that yield `torch.Tensor`s. Text tokens are represented by tensors with 1 entry, and audio tokens are tensors with 8 entries, corresponding to 8 [Mimi](https://huggingface.co/docs/transformers/en/model_doc/mimi) codebooks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,24 +21,19 @@ dependencies = [
     "transformers>=4.55.4",
 ]
 keywords = ["Liquid AI", "LFM", "LFM2", "Audio", "Speech-to-Speech"]
-
 [project.urls]
 Homepage = "https://www.liquid.ai/"
 Repository = "https://github.com/Liquid4All/liquid-audio/"
 Issues = "https://github.com/Liquid4All/liquid-audio/issues"
-
 [project.scripts]
 liquid-audio-demo = "liquid_audio.demo.chat:main [demo]"
-
 [project.optional-dependencies]
 demo = [
     "fastrtc[vad]>=0.0.30",
 ]
-
 [build-system]
 requires = ["uv_build>=0.8.13,<0.9.0"]
 build-backend = "uv_build"
-
 [dependency-groups]
 dev = [
     "ipython>=9.4.0",
@@ -46,13 +41,40 @@ dev = [
     "ruff>=0.12.10",
 ]
 
+# ---------------------------------------------------------------------------
+# AMD / ROCm support (community)
+#
+# These entries redirect PyTorch and related packages to the ROCm wheel index.
+# They are IGNORED on a standard pip install — they only take effect when
+# using `uv sync` / `uv run` from a local clone.
+#
+# To activate: append this section to your local pyproject.toml, then run:
+#   rm -rf .venv && uv venv && uv sync
+#
+# See README.md › Installation › AMD / ROCm for the full walkthrough.
+# ---------------------------------------------------------------------------
+[tool.uv.sources]
+apex        = { index = "rocm" }
+torch       = { index = "rocm" }
+triton      = { index = "rocm" }
+torchaudio  = { index = "rocm" }
+torchvision = { index = "rocm" }
+
+[[tool.uv.index]]
+name    = "pypi"
+url     = "https://pypi.org/simple"
+default = true
+
+[[tool.uv.index]]
+name = "rocm"
+url  = "https://download.pytorch.org/whl/nightly/rocm7.1"
+
 [tool.ruff]
 line-length = 127 # The GitHub editor is 127 chars wide
 extend-exclude = [
     "src/liquid_audio/model/conformer",
     "src/liquid_audio/moshi",
 ]
-
 [tool.ruff.lint]
 select = [
     # pycodestyle
@@ -76,7 +98,6 @@ select = [
     #ruff
     "RUF",
 ]
-
 ignore = [
     # These conflict with ruff format
     "W191",
@@ -103,7 +124,6 @@ ignore = [
     # Allow ABCs without abstract methods
     "B024",
 ]
-
 [tool.mypy]
 mypy_path = "src"
 packages = [
@@ -115,12 +135,9 @@ exclude = [
 warn_unused_configs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
-
 strict_equality = true
 extra_checks = true
-
 check_untyped_defs = true
-
 # TODO: check if needed
 [[tool.mypy.overrides]]
 module = [
@@ -129,7 +146,6 @@ module = [
     "datasets.*",
 ]
 ignore_missing_imports = true
-
 [[tool.mypy.overrides]]
 module = [
     'liquid_audio.moshi.*'


### PR DESCRIPTION
Closes #15

## What
Documents how to run liquid-audio on AMD GPUs using ROCm via `uv`. No source code changes — README and pyproject.toml only.

## Changes
- Restructures `## Installation` into `NVIDIA (default)` and `AMD / ROCm (community)` sub-sections
- Adds `[tool.uv.sources]` + `[[tool.uv.index]]` for ROCm 7.1 wheel index to `pyproject.toml`
- Notes Flash Attention 2 unavailability on AMD (falls back to torch SDPA)
- Corrects `uv add gradle` from the issue (not a real Python package) — demo deps are covered by `uv sync --extra demo`

Based on community testing reported in #15 by @gtherond.