### PR TITLE
demo: allow overriding the model repo via LFM_HF_REPO env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ pip install "liquid-audio [demo]"
 ```
 To launch the demo, use the command `liquid-audio-demo` on the terminal. The demo interface will be available via the url http://localhost:7860.
 
+By default the demo loads [LiquidAI/LFM2.5-Audio-1.5B](https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B). To run it with another checkpoint, e.g. the Japanese model [LiquidAI/LFM2.5-Audio-1.5B-JP](https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B-JP), set the `LFM_HF_REPO` environment variable:
+```bash
+LFM_HF_REPO=LiquidAI/LFM2.5-Audio-1.5B-JP liquid-audio-demo
+```
+
 ### Multi-turn, multi-modal chat
 For multi-turn chat with text and audio output, we use interleaved generation. The system prompt should be set to `Respond with interleaved text and audio.`. Here we use audio as the first user turn, and text as the second one
 

--- a/src/liquid_audio/demo/model.py
+++ b/src/liquid_audio/demo/model.py
@@ -1,6 +1,7 @@
 """Initialize models"""
 
 import logging
+import os
 
 import torch
 
@@ -10,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["lfm2_audio", "mimi", "proc"]
 
-HF_DIR = "LiquidAI/LFM2.5-Audio-1.5B"
+HF_DIR = os.environ.get("LFM_HF_REPO", "LiquidAI/LFM2.5-Audio-1.5B")
 
 logging.info("Loading processor")
 proc = LFM2AudioProcessor.from_pretrained(HF_DIR).eval()


### PR DESCRIPTION
## Motivation

The Gradio demo hardcodes `HF_DIR = "LiquidAI/LFM2.5-Audio-1.5B"`, so there is currently no way to run `liquid-audio-demo` with another checkpoint — most notably the recently released Japanese model [LiquidAI/LFM2.5-Audio-1.5B-JP](https://huggingface.co/LiquidAI/LFM2.5-Audio-1.5B-JP) — without editing the installed package.

## Changes

- `demo/model.py`: read the repo id from the `LFM_HF_REPO` environment variable, keeping `LiquidAI/LFM2.5-Audio-1.5B` as the default (no behavior change for existing users):
  ```bash
  LFM_HF_REPO=LiquidAI/LFM2.5-Audio-1.5B-JP liquid-audio-demo
  ```
- `README.md`: document the variable in the *Gradio demo* section.

## Testing

- Ran the demo with `LFM_HF_REPO=LiquidAI/LFM2.5-Audio-1.5B-JP` on an A100 (torch 2.5.1, transformers 4.55.4) and had a Japanese speech-to-speech conversation; without the variable the demo loads the default English checkpoint as before.
- `ruff check` / `ruff format --check` pass.